### PR TITLE
feat(bookmarkflow): enable Chrome Web Store install link

### DIFF
--- a/apps/site/src/pages/bookmarkflow/index.astro
+++ b/apps/site/src/pages/bookmarkflow/index.astro
@@ -53,7 +53,7 @@ const features = [
 
 // Web store links go here once published. While empty, each card shows "Soon".
 const browsers = [
-  { name: 'Chrome', icon: ChromeIcon, color: '#4285F4', href: '' },
+  { name: 'Chrome', icon: ChromeIcon, color: '#4285F4', href: 'https://chromewebstore.google.com/detail/hhgmpkajbebgnginafkmihhfdcegdjpe' },
   { name: 'Edge', icon: EdgeIcon, color: '#33A8E0', href: '' },
   { name: 'Firefox', icon: FirefoxIcon, color: '#FF7139', href: '' },
 ]
@@ -193,8 +193,8 @@ const browsers = [
           <div class="text-center mb-10">
             <h2 class="text-3xl max-md:text-2xl font-bold text-text mb-3">Install Bookmark Flow</h2>
             <p class="text-text-secondary max-w-xl mx-auto leading-relaxed">
-              Free and open to use. Pick your browser to add it. Store listings are on the
-              way, so the buttons go live soon.
+              Free and open to use. Add it to Chrome now. Edge and Firefox listings are
+              on the way.
             </p>
           </div>
 


### PR DESCRIPTION
## Summary

Bookmark Flow is now published on the Chrome Web Store, so this enables the Chrome install button on the landing page.

- Chrome install card links to the [store listing](https://chromewebstore.google.com/detail/hhgmpkajbebgnginafkmihhfdcegdjpe) and shows the "Install" button instead of "Soon"
- Updated the install section copy to reflect that Chrome is available now
- Edge and Firefox cards stay as "Soon" until their listings go live

## Test plan

- [ ] Visit `/bookmarkflow` and confirm the Chrome card opens the Web Store listing in a new tab
- [ ] Confirm Edge and Firefox still show "Soon"